### PR TITLE
CORE-6036: add BED to the InfoType enum so it doesn't break the data window.

### DIFF
--- a/de-lib/src/main/java/org/iplantc/de/client/models/viewer/InfoType.java
+++ b/de-lib/src/main/java/org/iplantc/de/client/models/viewer/InfoType.java
@@ -5,6 +5,7 @@ public enum InfoType {
     ACE("ace"),
     BAM("bam"),
     BASH("bash"),
+    BED("bed"),
     BLAST("blast"),
     BOWTIE("bowtie"),
     CLUSTALW("clustalw"),


### PR DESCRIPTION
On the upside I guess it's detecting them fine!